### PR TITLE
Fix typos in the commands

### DIFF
--- a/Instructions/Labs/0603-Configuring Internet Explorer Enterprise Mode.md
+++ b/Instructions/Labs/0603-Configuring Internet Explorer Enterprise Mode.md
@@ -136,7 +136,7 @@ Adatum is using a web based application for travel requests located at intranet.
 Copy C:\Windows\PolicyDefinitions\inetres.admx \\LON-DC1\SYSVOL\Adatum.com\Policies\PolicyDefinitions\inetres.admx
 ```
 ```
-Copy C:\Windows\PolicyDefinitions\en-US\inetres.adml \\\ON-DC1\SYSVOL\Adatum.com\Policies\PolicyDefinitions\en-US\inetres.adml
+Copy C:\Windows\PolicyDefinitions\en-US\inetres.adml \\LON-DC1\SYSVOL\Adatum.com\Policies\PolicyDefinitions\en-US\inetres.adml
 ```
 
 19.  Sign out of **LON-CL1**.

--- a/Instructions/Labs/0801-Configuring and Managing Permissions and Shares.md
+++ b/Instructions/Labs/0801-Configuring and Managing Permissions and Shares.md
@@ -86,7 +86,7 @@ Your manager has advised you to create file shares for the Marketing and IT depa
 13. At the command prompt, type the following command, and then press **Enter**.
 
     ```
-    net view \\\\lon-cl1
+    net view \\lon-cl1
     ```
 
     _**Note**: This will show you all shares created on LON-CL1_

--- a/Instructions/Labs/0801-Configuring and Managing Permissions and Shares.md
+++ b/Instructions/Labs/0801-Configuring and Managing Permissions and Shares.md
@@ -192,7 +192,7 @@ Your manager has advised you to create file shares for the Marketing and IT depa
 
 10. Right-click the **empty space**, select **New**, select **Text Document**, and then type **File20** as the name of the file.
     
-    _**Note**: April has local file permissions to create a new file in the Marketing
+    _**Note**: Beth has local file permissions to create a new file in the Marketing
 	folder because you configured permissions by using the Advanced Sharing
 	feature. This modified only the share permissions, while the default local
 	file permissions were not modified. By default, Authenticated Users have the
@@ -202,7 +202,7 @@ Your manager has advised you to create file shares for the Marketing and IT depa
     pane, right-click the **empty space**, select **New**, select **Text
     Document**, and then type **File21** as the name of the file.
     
-    _**Note**: April is able to create a file, because you configured permissions by
+    _**Note**: Beth is able to create a file, because you configured permissions by
 	using File Sharing. Members of the IT group have local file permissions to
 	the IT folder._
     

--- a/Instructions/Labs/1103-Troubleshooting Application Compatibility Issues.md
+++ b/Instructions/Labs/1103-Troubleshooting Application Compatibility Issues.md
@@ -115,7 +115,7 @@ Benjamin has filed an incident report that states that the Stock Viewer applicat
 4.  At the command prompt, type the following command, and then press **Enter**:
 
     ```
-    Sdbinst C:\\AdatumACT.sdb
+    Sdbinst C:\AdatumACT.sdb
     ```
 
 5.  On the desktop, on the taskbar, select the **File Explorer** icon.

--- a/Instructions/Labs/1202-Recovering using a Restore Point.md
+++ b/Instructions/Labs/1202-Recovering using a Restore Point.md
@@ -36,7 +36,7 @@ return to a previous working state.
     **Enter**:
 
     ``` 
-    Checkpoint-Computer -Description "Lab Start"\
+    Checkpoint-Computer -Description "Lab Start"
     ```
 
 1.  When complete, close the PowerShell Window.


### PR DESCRIPTION
## Lab: 0603, 0801, 1103, 1202

Changes proposed in this pull request:

- Fix a typo in the `Copy C:\Windows\PolicyDefinitions\en-US\inetres.adml \\LON-DC1\SYSVOL\Adatum.com\Policies\PolicyDefinitions\en-US\inetres.adml` command in 0603.
- Fix a typo in the `net view \\lon-cl1` command in 0801.
- Fix a name in the notes in 0801.
- Fix a typo in the `Sdbinst C:\AdatumACT.sdb` command in 1103.
- Fix a typo in the `Checkpoint-Computer -Description "Lab Start"` command in 1202.