### PR TITLE
Missing curly bracket.

### DIFF
--- a/Instructions/Labs/0503-Administering Windows 10 Using Remote Management.md
+++ b/Instructions/Labs/0503-Administering Windows 10 Using Remote Management.md
@@ -31,7 +31,7 @@ Invoke-Command -ComputerName SEA-SVR2 -ScriptBlock {Get-ChildItem "C:\Program Fi
 5. To view the the System event log on SEA-SVR2, in the Windows PowerShell window, type the following command, and then press **Enter**:
 
 ```
-Invoke-Command –ComputerName SEA-SVR2 –ScriptBlock {Get-EventLog –log system
+Invoke-Command –ComputerName SEA-SVR2 –ScriptBlock {Get-EventLog –log system}
 ```
 
 6. To determine if the WinRM service is running on SEA-SVR2, in the Windows PowerShell window, type the following command, and then press **Enter**:


### PR DESCRIPTION
The command for viewing the event log on SEA-SVR2 is missing a curly bracket on the end.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-