### PR TITLE
Update 0101-Deploying Windows using Windows ADK tools.md

### DIFF
--- a/Instructions/Labs/0101-Deploying Windows using Windows ADK tools.md
+++ b/Instructions/Labs/0101-Deploying Windows using Windows ADK tools.md
@@ -116,7 +116,7 @@ sysprep
 
 5. On the **Specify Generation** page, ensure that **Generation 1** is selected and then select **Next**.
 
-6. On the **Assign Memory** page, next to **Startup memory** type **8192** and then select **Next**.
+6. On the **Assign Memory** page, next to **Startup memory** type **4096** and then select **Next**.
 
 7. On the **Configure Networking** page, next to **Connection**, select **Internal Network** and then select **Next**.
 


### PR DESCRIPTION
Changed new VM RAM to 4096 to remove error in next lab of the hyperv host not having enough RAM to start both Win81Source and Computer1.

# Module: 00
## Lab/Demo: 00

Fixes # .

Changes proposed in this pull request:

-
-
-