### PR TITLE
Typo, we need to click on "Apps" in the Settings app, not the Start menu.

### DIFF
--- a/Instructions/Labs/0101-Deploying Windows Desktop settings using a provisioning package.md
+++ b/Instructions/Labs/0101-Deploying Windows Desktop settings using a provisioning package.md
@@ -142,7 +142,7 @@ As part of the Desktop Administration team at Contoso, you have been tasked with
 
 3. On the **System** page, verify that the Computer name is **SEA-CL** followed by two random numbers.
 
-4. On the Start menu, select **Apps** and then select **Apps & features**.
+4. On the Navigation menu of Settings, select **Apps** and then select **Apps & features**.
 
 5. Verify that both **Microsoft Power BI Desktop (x64)** and **PowerToys (Preview) x64** are both listed as installed applications.
 


### PR DESCRIPTION
Typo, we need to click on "Apps" in the Settings app, not the Start menu.

# Module: 01
## Lab/Demo: 0101
### Task 4
#### Step 4

Changes proposed in this pull request:

- Typo, we need to click on "Apps" in the Settings app, not the Start menu.
